### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0 (2021-04-16)
+
+- Updated the demo code to use `<sky-data-manager-toolbar-primary-item>` for the primary button. [#28](https://github.com/blackbaud/skyux-data-manager/pull/28)
+
 # 4.0.2 (2021-01-28)
 
 - Fixed the data manager toolbar component to only execute searches when users press "Enter" or select the search button. [#25](https://github.com/blackbaud/skyux-data-manager/pull/25)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/data-manager",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1673,9 +1673,9 @@
       }
     },
     "@skyux/forms": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/@skyux/forms/-/forms-4.16.3.tgz",
-      "integrity": "sha512-k8yDXAHC41ns1+XWVFemW7B69jduiw0X/DwqevrvtSNhBRDrlnR7R17pi/PeIF3qUJ+OSIO+BAdCM+x94afhdw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@skyux/forms/-/forms-4.16.4.tgz",
+      "integrity": "sha512-8WIh07g+miFIgB8zRsVw/qhc0o1mCncLjWTnNwlI2frXYjfCWb4CheWWS4tH3KB00VHZ1SpWwsclRXD2ov2Vjw==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/data-manager",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "SKY UX Data Manager",
   "scripts": {
     "build": "skyux build-public-library",
@@ -58,7 +58,7 @@
     "@skyux/data-manager": "4.0.2",
     "@skyux/datetime": "4.10.2",
     "@skyux/docs-tools": "4.9.0",
-    "@skyux/forms": "4.16.3",
+    "@skyux/forms": "4.16.4",
     "@skyux/http": "4.2.0",
     "@skyux/i18n": "4.1.0",
     "@skyux/indicators": "4.9.2",


### PR DESCRIPTION
- Updated the demo code to use `<sky-data-manager-toolbar-primary-item>` for the primary button. [#28](https://github.com/blackbaud/skyux-data-manager/pull/28)
